### PR TITLE
Fix join sound constant for Spigot 1.21

### DIFF
--- a/src/main/java/de/lunarismc/LobbySystem.java
+++ b/src/main/java/de/lunarismc/LobbySystem.java
@@ -202,9 +202,9 @@ public class LobbySystem extends JavaPlugin implements Listener {
         p.sendTitle(title, subtitle, 10, 60, 10);
         Sound s;
         try {
-            s = Sound.valueOf(getConfig().getString("join.sound", "LEVEL_UP"));
+            s = Sound.valueOf(getConfig().getString("join.sound", "ENTITY_PLAYER_LEVELUP"));
         } catch (IllegalArgumentException ex) {
-            s = Sound.LEVEL_UP;
+            s = Sound.ENTITY_PLAYER_LEVELUP;
         }
         p.playSound(p.getLocation(), s, 1f, 1f);
         setLobbyItems(p);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,7 @@ broadcast:
 join:
   title: '&6★ &eWillkommen auf &lLUNARISMC.de &6★'
   subtitle: '&7Version: &f1.8 - 1.21'
-  sound: LEVEL_UP
+  sound: ENTITY_PLAYER_LEVELUP
   items:
     navigator:
       slot: 0


### PR DESCRIPTION
## Summary
- update join sound to `ENTITY_PLAYER_LEVELUP`
- update default sound in `config.yml`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871960379f0832eb7306e00008bc2ca